### PR TITLE
Check for existing class when generating for input

### DIFF
--- a/node-compiler/src/core/ScalaGenDirect.js
+++ b/node-compiler/src/core/ScalaGenDirect.js
@@ -590,17 +590,20 @@ class ClassTracker {
         };
       });
 
-      classes.push({
-        name: prefix + type.toString(),
-        members: props,
-        open: false,
-        extendsC: [],
-        linkedField: false,
-        spreadFrags: [],
-        useNulls: true,
-      });
+      if(!classes.find((x) => x.name == prefix + type.toString())) {
+        classes.push({
+          name: prefix + type.toString(),
+          members: props,
+          open: false,
+          extendsC: [],
+          linkedField: false,
+          spreadFrags: [],
+          useNulls: true,
+        });
 
-      this.newFactoryMethod("apply", prefix + type.toString(), props, [], false, [], true, false, prefix + type.toString())
+        this.newFactoryMethod("apply", prefix + type.toString(), props, [], false, [], true, false, prefix + type.toString())
+      }
+      
       return [{
         name: prefix + type.toString(),
         mods: [INPUT_MOD],


### PR DESCRIPTION
Currently if an input type contains two fields of the same (class) type, scala-relay generates two copies of the factory object definition (it seems like the duplicate class gets filtered out somewhere downstream, but the duplicate `newFactoryMethod` isn't?), leading to a compile failure.
I don't know if this is the most correct solution, but it seems to work.

(I have a simple test case on the SBT plugin side which I can submit separately).