### PR TITLE
Inline fragments should be a subtype of 'Block' fragments

### DIFF
--- a/relay-macro/src/main/scala/relay/gql/TaggedNode.scala
+++ b/relay-macro/src/main/scala/relay/gql/TaggedNode.scala
@@ -114,5 +114,4 @@ trait ConcreteRequest extends TaggedNode
 @js.native
 trait TaggedNodeQuery[F[_], O, +X] extends TaggedNode
 
-trait Block
 trait Inline

--- a/relay-macro/src/main/scala/relay/gql/package.scala
+++ b/relay-macro/src/main/scala/relay/gql/package.scala
@@ -1,6 +1,8 @@
 package relay
 
 package object gql {
+  type Block = Any
+
   type ReaderFragment[F[_], O] = TaggedNodeQuery[F, O, Block]
 
   type ReaderInlineDataFragment[F[_], O] = TaggedNodeQuery[F, O, Inline]


### PR DESCRIPTION
This is so `useFragment` can be called on fragments with the `@inline` annotation.