### PR TITLE
GC-3162: Change nullable input field to undefined or null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changes
 
+### 0.46.0
+
+- Allow `null` or `js.undefined` for optional input fields.
+
 ### 0.45.0
 
 - Use shared input types.

--- a/sbt-scala-relay/src/main/scala/com/goodcover/relay/codegen/ExecutableDefinitionWriter.scala
+++ b/sbt-scala-relay/src/main/scala/com/goodcover/relay/codegen/ExecutableDefinitionWriter.scala
@@ -65,7 +65,7 @@ abstract class ExecutableDefinitionWriter(
   ): Unit = {
     // TODO: This typeName stuff is weird.
     val typeName  = if (hasSelections) s"$definitionName.${name.capitalize}" else innerType(tpe)
-    val scalaType = typeConverter.convertToScalaType(tpe, typeName, fieldDefinitionDirectives, fullyQualified = false)
+    val scalaType = typeConverter.convertToScalaType(tpe, typeName, fieldDefinitionDirectives, fullyQualified = false, input = false)
     scalaWriter.writeField(Term.Name(name), scalaType, None, "  ")
   }
 
@@ -244,7 +244,7 @@ abstract class ExecutableDefinitionWriter(
     fieldDefinitionDirectives: List[Directive]
   ): Unit = {
     val typeName  = if (hasSelections) typePrefix + name.capitalize else innerType(tpe)
-    val scalaType = typeConverter.convertToScalaType(tpe, typeName, fieldDefinitionDirectives, fullyQualified = false)
+    val scalaType = typeConverter.convertToScalaType(tpe, typeName, fieldDefinitionDirectives, fullyQualified = false, input = false)
     scalaWriter.writeField(Term.Name(name), scalaType, None, "    ")
   }
 

--- a/sbt-scala-relay/src/main/scala/com/goodcover/relay/codegen/InputWriter.scala
+++ b/sbt-scala-relay/src/main/scala/com/goodcover/relay/codegen/InputWriter.scala
@@ -16,9 +16,9 @@ class InputWriter(writer: Writer, input: InputObjectTypeDefinition, document: Do
   private val parameters = input.fields.map { field =>
     val tpe       = field.ofType
     val typeName  = innerType(tpe)
-    val scalaType = typeConverter.convertToScalaType(tpe, typeName, field.directives, fullyQualified = false)
+    val scalaType = typeConverter.convertToScalaType(tpe, typeName, field.directives, fullyQualified = false, input = true)
     // TODO: Default value.
-    val initializer = if (tpe.nonNull) None else Some("null")
+    val initializer = if (tpe.nonNull) None else Some("js.undefined")
     Parameter(Term.Name(field.name), scalaType, initializer)
   }
 
@@ -48,7 +48,7 @@ class InputWriter(writer: Writer, input: InputObjectTypeDefinition, document: Do
 
   private def writeInputField(name: String, tpe: Type, fieldDefinitionDirectives: List[Directive]): Unit = {
     val typeName  = innerType(tpe)
-    val scalaType = typeConverter.convertToScalaType(tpe, typeName, fieldDefinitionDirectives, fullyQualified = false)
+    val scalaType = typeConverter.convertToScalaType(tpe, typeName, fieldDefinitionDirectives, fullyQualified = false, input = true)
     scalaWriter.writeField(Term.Name(name), scalaType, None, "  ")
   }
 

--- a/sbt-scala-relay/src/main/scala/com/goodcover/relay/codegen/OperationInputWriter.scala
+++ b/sbt-scala-relay/src/main/scala/com/goodcover/relay/codegen/OperationInputWriter.scala
@@ -27,9 +27,9 @@ class OperationInputWriter(
   private val parameters = operation.variableDefinitions.map { variable =>
     val tpe       = variable.variableType
     val typeName  = innerType(tpe)
-    val scalaType = typeConverter.convertToScalaType(tpe, typeName, variable.directives, fullyQualified = true)
+    val scalaType = typeConverter.convertToScalaType(tpe, typeName, variable.directives, fullyQualified = true, input = true)
     // TODO: Default value.
-    val initializer = if (tpe.nonNull) None else Some("null")
+    val initializer = if (tpe.nonNull) None else Some("js.undefined")
     Parameter(Term.Name(variable.name), scalaType, initializer)
   }
 

--- a/sbt-scala-relay/src/main/scala/com/goodcover/relay/codegen/TypeConverter.scala
+++ b/sbt-scala-relay/src/main/scala/com/goodcover/relay/codegen/TypeConverter.scala
@@ -22,10 +22,13 @@ class TypeConverter(schema: GraphQLSchema, typeMappings: Map[String, String]) {
     tpe: Type,
     gqlTypeName: String,
     fieldDefinitionDirectives: List[Directive],
-    fullyQualified: Boolean
+    fullyQualified: Boolean,
+    input: Boolean
   ): String = {
     val builder = new StringBuilder()
     def loop(tpe: Type): Unit = {
+      if (!tpe.nonNull && input)
+        builder.append("js.UndefOr[")
       tpe match {
         case Type.NamedType(_, _) =>
           builder.append(convertToScalaType(gqlTypeName, fullyQualified))
@@ -40,7 +43,8 @@ class TypeConverter(schema: GraphQLSchema, typeMappings: Map[String, String]) {
           builder.append(']')
       }
       if (!tpe.nonNull) {
-        val _ = builder.append(" | Null")
+        builder.append(" | Null")
+        val _ = if (input) builder.append(']')
       }
     }
 

--- a/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestListVariableQuery.graphql.ts
+++ b/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestListVariableQuery.graphql.ts
@@ -23,6 +23,7 @@ query TestListVariableQuery(
   $as: [String!]!
 ) {
   listVariable(as: $as) {
+    __typename
     id
   }
 }
@@ -38,37 +39,38 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "as",
-        "variableName": "as"
-      }
-    ],
-    "concreteType": "Node",
-    "kind": "LinkedField",
-    "name": "listVariable",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "id",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "as",
+    "variableName": "as"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestListVariableQuery",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "listVariable",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Query",
     "abstractKey": null
   },
@@ -77,15 +79,35 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "TestListVariableQuery",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "listVariable",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "bdfbd3c350023c33e3f495ef5208b65d",
+    "cacheID": "738c663f5b699cf3e6e61df8a4bc4c24",
     "id": null,
     "metadata": {},
     "name": "TestListVariableQuery",
     "operationKind": "query",
-    "text": "query TestListVariableQuery(\n  $as: [String!]!\n) {\n  listVariable(as: $as) {\n    id\n  }\n}\n"
+    "text": "query TestListVariableQuery(\n  $as: [String!]!\n) {\n  listVariable(as: $as) {\n    __typename\n    id\n  }\n}\n"
   }
 };
 })();

--- a/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestMultipleVariablesQuery.graphql.ts
+++ b/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestMultipleVariablesQuery.graphql.ts
@@ -25,6 +25,7 @@ query TestMultipleVariablesQuery(
   $b: String!
 ) {
   multipleVariables(a: $a, b: $b) {
+    __typename
     id
   }
 }
@@ -45,42 +46,43 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "a",
-        "variableName": "a"
-      },
-      {
-        "kind": "Variable",
-        "name": "b",
-        "variableName": "b"
-      }
-    ],
-    "concreteType": "Node",
-    "kind": "LinkedField",
-    "name": "multipleVariables",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "id",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "a",
+    "variableName": "a"
+  },
+  {
+    "kind": "Variable",
+    "name": "b",
+    "variableName": "b"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestMultipleVariablesQuery",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "multipleVariables",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Query",
     "abstractKey": null
   },
@@ -89,15 +91,35 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "TestMultipleVariablesQuery",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "multipleVariables",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "f3583e1b46be02d1bc9b5d7b9df9964e",
+    "cacheID": "a443434c6d4c7fbc04443d83c205066a",
     "id": null,
     "metadata": {},
     "name": "TestMultipleVariablesQuery",
     "operationKind": "query",
-    "text": "query TestMultipleVariablesQuery(\n  $a: String!\n  $b: String!\n) {\n  multipleVariables(a: $a, b: $b) {\n    id\n  }\n}\n"
+    "text": "query TestMultipleVariablesQuery(\n  $a: String!\n  $b: String!\n) {\n  multipleVariables(a: $a, b: $b) {\n    __typename\n    id\n  }\n}\n"
   }
 };
 })();

--- a/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestNestedObjectResponseQuery.graphql.ts
+++ b/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestNestedObjectResponseQuery.graphql.ts
@@ -1,0 +1,91 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+export type TestNestedObjectResponseQueryVariables = {};
+export type TestNestedObjectResponseQueryResponse = {
+    readonly nestedObjectResponse: {
+        readonly output: {
+            readonly b: string | null;
+        } | null;
+    } | null;
+};
+export type TestNestedObjectResponseQuery = {
+    readonly response: TestNestedObjectResponseQueryResponse;
+    readonly variables: TestNestedObjectResponseQueryVariables;
+};
+
+
+
+/*
+query TestNestedObjectResponseQuery {
+  nestedObjectResponse {
+    output {
+      b
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "NestedOutput",
+    "kind": "LinkedField",
+    "name": "nestedObjectResponse",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Output",
+        "kind": "LinkedField",
+        "name": "output",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "b",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TestNestedObjectResponseQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "TestNestedObjectResponseQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "cacheID": "a3eb84d598dea58055a7058a7a71eae2",
+    "id": null,
+    "metadata": {},
+    "name": "TestNestedObjectResponseQuery",
+    "operationKind": "query",
+    "text": "query TestNestedObjectResponseQuery {\n  nestedObjectResponse {\n    output {\n      b\n    }\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = 'd5ffd04bedca902ff8f1e9554ce81c5e';
+export default node;

--- a/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestNestedObjectVariableQuery.graphql.ts
+++ b/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestNestedObjectVariableQuery.graphql.ts
@@ -29,6 +29,7 @@ query TestNestedObjectVariableQuery(
   $nested: Nested
 ) {
   nestedObjectVariable(nested: $nested) {
+    __typename
     id
   }
 }
@@ -44,37 +45,38 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "nested",
-        "variableName": "nested"
-      }
-    ],
-    "concreteType": "Node",
-    "kind": "LinkedField",
-    "name": "nestedObjectVariable",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "id",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "nested",
+    "variableName": "nested"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestNestedObjectVariableQuery",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "nestedObjectVariable",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Query",
     "abstractKey": null
   },
@@ -83,15 +85,35 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "TestNestedObjectVariableQuery",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "nestedObjectVariable",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "821c92ae2cfb86f1c8e42afa85a4ea75",
+    "cacheID": "61d2d5449b0e48535e74dd17e4daed9c",
     "id": null,
     "metadata": {},
     "name": "TestNestedObjectVariableQuery",
     "operationKind": "query",
-    "text": "query TestNestedObjectVariableQuery(\n  $nested: Nested\n) {\n  nestedObjectVariable(nested: $nested) {\n    id\n  }\n}\n"
+    "text": "query TestNestedObjectVariableQuery(\n  $nested: Nested\n) {\n  nestedObjectVariable(nested: $nested) {\n    __typename\n    id\n  }\n}\n"
   }
 };
 })();

--- a/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestNoVariablesQuery.graphql.ts
+++ b/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestNoVariablesQuery.graphql.ts
@@ -19,39 +19,40 @@ export type TestNoVariablesQuery = {
 /*
 query TestNoVariablesQuery {
   noVariables {
+    __typename
     id
   }
 }
 */
 
 const node: ConcreteRequest = (function(){
-var v0 = [
-  {
-    "alias": null,
-    "args": null,
-    "concreteType": "Node",
-    "kind": "LinkedField",
-    "name": "noVariables",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "id",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
-  }
-];
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
     "name": "TestNoVariablesQuery",
-    "selections": (v0/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "noVariables",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Query",
     "abstractKey": null
   },
@@ -60,15 +61,35 @@ return {
     "argumentDefinitions": [],
     "kind": "Operation",
     "name": "TestNoVariablesQuery",
-    "selections": (v0/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "noVariables",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v0/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "0ce07dd31c974ecc80ead2d604b9c0f6",
+    "cacheID": "ccbb9e9444e304c2861f66b66321eaf2",
     "id": null,
     "metadata": {},
     "name": "TestNoVariablesQuery",
     "operationKind": "query",
-    "text": "query TestNoVariablesQuery {\n  noVariables {\n    id\n  }\n}\n"
+    "text": "query TestNoVariablesQuery {\n  noVariables {\n    __typename\n    id\n  }\n}\n"
   }
 };
 })();

--- a/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestObjectVariableQuery.graphql.ts
+++ b/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestObjectVariableQuery.graphql.ts
@@ -26,6 +26,7 @@ query TestObjectVariableQuery(
   $input: Input!
 ) {
   objectVariable(input: $input) {
+    __typename
     id
   }
 }
@@ -41,37 +42,38 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
-      }
-    ],
-    "concreteType": "Node",
-    "kind": "LinkedField",
-    "name": "objectVariable",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "id",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestObjectVariableQuery",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "objectVariable",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Query",
     "abstractKey": null
   },
@@ -80,15 +82,35 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "TestObjectVariableQuery",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "objectVariable",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "d6f2445fbd0cbeb633f27e872a22d5f2",
+    "cacheID": "b57eec83e26769b68e5f2b4b2af1334f",
     "id": null,
     "metadata": {},
     "name": "TestObjectVariableQuery",
     "operationKind": "query",
-    "text": "query TestObjectVariableQuery(\n  $input: Input!\n) {\n  objectVariable(input: $input) {\n    id\n  }\n}\n"
+    "text": "query TestObjectVariableQuery(\n  $input: Input!\n) {\n  objectVariable(input: $input) {\n    __typename\n    id\n  }\n}\n"
   }
 };
 })();

--- a/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestOptionalListVariableQuery.graphql.ts
+++ b/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestOptionalListVariableQuery.graphql.ts
@@ -23,6 +23,7 @@ query TestOptionalListVariableQuery(
   $as: [String!]
 ) {
   listVariable(as: $as) {
+    __typename
     id
   }
 }
@@ -38,37 +39,38 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "as",
-        "variableName": "as"
-      }
-    ],
-    "concreteType": "Node",
-    "kind": "LinkedField",
-    "name": "listVariable",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "id",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "as",
+    "variableName": "as"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestOptionalListVariableQuery",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "listVariable",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Query",
     "abstractKey": null
   },
@@ -77,15 +79,35 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "TestOptionalListVariableQuery",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "listVariable",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "07f082c03659cab4b4ecf8feb5e6f737",
+    "cacheID": "8cb009685ccc1785fba4816343ab804d",
     "id": null,
     "metadata": {},
     "name": "TestOptionalListVariableQuery",
     "operationKind": "query",
-    "text": "query TestOptionalListVariableQuery(\n  $as: [String!]\n) {\n  listVariable(as: $as) {\n    id\n  }\n}\n"
+    "text": "query TestOptionalListVariableQuery(\n  $as: [String!]\n) {\n  listVariable(as: $as) {\n    __typename\n    id\n  }\n}\n"
   }
 };
 })();

--- a/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestOptionalObjectVariableQuery.graphql.ts
+++ b/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestOptionalObjectVariableQuery.graphql.ts
@@ -26,6 +26,7 @@ query TestOptionalObjectVariableQuery(
   $input: Input
 ) {
   objectVariable(input: $input) {
+    __typename
     id
   }
 }
@@ -41,37 +42,38 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
-      }
-    ],
-    "concreteType": "Node",
-    "kind": "LinkedField",
-    "name": "objectVariable",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "id",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestOptionalObjectVariableQuery",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "objectVariable",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Query",
     "abstractKey": null
   },
@@ -80,15 +82,35 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "TestOptionalObjectVariableQuery",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "objectVariable",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "7bde3ee007526d42c4afab7761bd15fe",
+    "cacheID": "a4de4acf7c3991f740aec1845562df7e",
     "id": null,
     "metadata": {},
     "name": "TestOptionalObjectVariableQuery",
     "operationKind": "query",
-    "text": "query TestOptionalObjectVariableQuery(\n  $input: Input\n) {\n  objectVariable(input: $input) {\n    id\n  }\n}\n"
+    "text": "query TestOptionalObjectVariableQuery(\n  $input: Input\n) {\n  objectVariable(input: $input) {\n    __typename\n    id\n  }\n}\n"
   }
 };
 })();

--- a/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestOptionalPrimitiveVariableQuery.graphql.ts
+++ b/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestOptionalPrimitiveVariableQuery.graphql.ts
@@ -23,6 +23,7 @@ query TestOptionalPrimitiveVariableQuery(
   $a: String
 ) {
   primitiveVariable(a: $a) {
+    __typename
     id
   }
 }
@@ -38,37 +39,38 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "a",
-        "variableName": "a"
-      }
-    ],
-    "concreteType": "Node",
-    "kind": "LinkedField",
-    "name": "primitiveVariable",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "id",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "a",
+    "variableName": "a"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestOptionalPrimitiveVariableQuery",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "primitiveVariable",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Query",
     "abstractKey": null
   },
@@ -77,15 +79,35 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "TestOptionalPrimitiveVariableQuery",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "primitiveVariable",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "e3260e365d12e54904a328e80b465cc2",
+    "cacheID": "1504e6ac28226b64b19fd74a1a8f418a",
     "id": null,
     "metadata": {},
     "name": "TestOptionalPrimitiveVariableQuery",
     "operationKind": "query",
-    "text": "query TestOptionalPrimitiveVariableQuery(\n  $a: String\n) {\n  primitiveVariable(a: $a) {\n    id\n  }\n}\n"
+    "text": "query TestOptionalPrimitiveVariableQuery(\n  $a: String\n) {\n  primitiveVariable(a: $a) {\n    __typename\n    id\n  }\n}\n"
   }
 };
 })();

--- a/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestPrimitiveVariableQuery.graphql.ts
+++ b/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/expected/TestPrimitiveVariableQuery.graphql.ts
@@ -23,6 +23,7 @@ query TestPrimitiveVariableQuery(
   $a: String!
 ) {
   primitiveVariable(a: $a) {
+    __typename
     id
   }
 }
@@ -38,37 +39,38 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "a",
-        "variableName": "a"
-      }
-    ],
-    "concreteType": "Node",
-    "kind": "LinkedField",
-    "name": "primitiveVariable",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "id",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "a",
+    "variableName": "a"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "TestPrimitiveVariableQuery",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "primitiveVariable",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Query",
     "abstractKey": null
   },
@@ -77,15 +79,35 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "TestPrimitiveVariableQuery",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "primitiveVariable",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "94182917396be5d023cb15040da1e88d",
+    "cacheID": "8f796d0a09436b81c58fbeda4cf3d2f9",
     "id": null,
     "metadata": {},
     "name": "TestPrimitiveVariableQuery",
     "operationKind": "query",
-    "text": "query TestPrimitiveVariableQuery(\n  $a: String!\n) {\n  primitiveVariable(a: $a) {\n    id\n  }\n}\n"
+    "text": "query TestPrimitiveVariableQuery(\n  $a: String!\n) {\n  primitiveVariable(a: $a) {\n    __typename\n    id\n  }\n}\n"
   }
 };
 })();

--- a/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/src/main/resources/graphql/Schema.graphqls
+++ b/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/src/main/resources/graphql/Schema.graphqls
@@ -13,6 +13,7 @@ type Query {
     multipleVariables(a: String, b: String): Node!
     primitiveResponse(a: String): String!
     optionalPrimitiveResponse(a: String): String
+    nestedObjectResponse: NestedOutput
     listResponse(a: String): [String!]!
 }
 
@@ -24,6 +25,14 @@ input Nested {
     input: Input!
 }
 
-type Node {
+type Output {
+    b: String
+}
+
+type NestedOutput {
+    output: Output
+}
+
+interface Node {
     id: ID!
 }

--- a/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/src/main/resources/graphql/Test.graphql
+++ b/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/src/main/resources/graphql/Test.graphql
@@ -63,3 +63,11 @@ query TestOptionalPrimitiveResponseQuery($a: String!) {
 query TestListResponseQuery($a: String!) {
     listResponse(a: $a)
 }
+
+query TestNestedObjectResponseQuery {
+    nestedObjectResponse {
+        output {
+            b
+        }
+    }
+}

--- a/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/test
+++ b/sbt-scala-relay/src/sbt-test/relay-compiler/typescript/test
@@ -2,6 +2,7 @@
 $ must-mirror target/scala-2.13/resource_managed/main/__generated__/TestListResponseQuery.graphql.ts expected/TestListResponseQuery.graphql.ts
 $ must-mirror target/scala-2.13/resource_managed/main/__generated__/TestListVariableQuery.graphql.ts expected/TestListVariableQuery.graphql.ts
 $ must-mirror target/scala-2.13/resource_managed/main/__generated__/TestMultipleVariablesQuery.graphql.ts expected/TestMultipleVariablesQuery.graphql.ts
+$ must-mirror target/scala-2.13/resource_managed/main/__generated__/TestNestedObjectResponseQuery.graphql.ts expected/TestNestedObjectResponseQuery.graphql.ts
 $ must-mirror target/scala-2.13/resource_managed/main/__generated__/TestNestedObjectVariableQuery.graphql.ts expected/TestNestedObjectVariableQuery.graphql.ts
 $ must-mirror target/scala-2.13/resource_managed/main/__generated__/TestNoVariablesQuery.graphql.ts expected/TestNoVariablesQuery.graphql.ts
 $ must-mirror target/scala-2.13/resource_managed/main/__generated__/TestObjectVariableQuery.graphql.ts expected/TestObjectVariableQuery.graphql.ts

--- a/sbt-scala-relay/src/sbt-test/relay-convert/mutation/expected/TestNestedObjectVariableMutation.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/mutation/expected/TestNestedObjectVariableMutation.scala
@@ -13,12 +13,12 @@ mutation TestNestedObjectVariableMutation($nested: Nested) {
 */
 
 trait TestNestedObjectVariableMutationInput extends js.Object {
-  val nested: Nested | Null
+  val nested: js.UndefOr[Nested | Null]
 }
 
 object TestNestedObjectVariableMutationInput {
   def apply(
-    nested: Nested | Null = null
+    nested: js.UndefOr[Nested | Null] = js.undefined
   ): TestNestedObjectVariableMutationInput =
     js.Dynamic.literal(
       nested = nested
@@ -39,7 +39,7 @@ object TestNestedObjectVariableMutation extends _root_.com.goodcover.relay.Mutat
   }
 
   def newInput(
-    nested: _root_.relay.generated.Nested | Null = null
+    nested: js.UndefOr[_root_.relay.generated.Nested | Null] = js.undefined
   ): _root_.relay.generated.TestNestedObjectVariableMutationInput =
     _root_.relay.generated.TestNestedObjectVariableMutationInput(
       nested

--- a/sbt-scala-relay/src/sbt-test/relay-convert/mutation/expected/TestOptionalListVariableMutation.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/mutation/expected/TestOptionalListVariableMutation.scala
@@ -13,12 +13,12 @@ mutation TestOptionalListVariableMutation($as: [String!]) {
 */
 
 trait TestOptionalListVariableMutationInput extends js.Object {
-  val as: js.Array[String] | Null
+  val as: js.UndefOr[js.Array[String] | Null]
 }
 
 object TestOptionalListVariableMutationInput {
   def apply(
-    as: js.Array[String] | Null = null
+    as: js.UndefOr[js.Array[String] | Null] = js.undefined
   ): TestOptionalListVariableMutationInput =
     js.Dynamic.literal(
       as = as
@@ -39,7 +39,7 @@ object TestOptionalListVariableMutation extends _root_.com.goodcover.relay.Mutat
   }
 
   def newInput(
-    as: js.Array[String] | Null = null
+    as: js.UndefOr[js.Array[String] | Null] = js.undefined
   ): _root_.relay.generated.TestOptionalListVariableMutationInput =
     _root_.relay.generated.TestOptionalListVariableMutationInput(
       as

--- a/sbt-scala-relay/src/sbt-test/relay-convert/mutation/expected/TestOptionalObjectVariableMutation.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/mutation/expected/TestOptionalObjectVariableMutation.scala
@@ -13,12 +13,12 @@ mutation TestOptionalObjectVariableMutation($input: Input) {
 */
 
 trait TestOptionalObjectVariableMutationInput extends js.Object {
-  val input: Input | Null
+  val input: js.UndefOr[Input | Null]
 }
 
 object TestOptionalObjectVariableMutationInput {
   def apply(
-    input: Input | Null = null
+    input: js.UndefOr[Input | Null] = js.undefined
   ): TestOptionalObjectVariableMutationInput =
     js.Dynamic.literal(
       input = input
@@ -39,7 +39,7 @@ object TestOptionalObjectVariableMutation extends _root_.com.goodcover.relay.Mut
   }
 
   def newInput(
-    input: _root_.relay.generated.Input | Null = null
+    input: js.UndefOr[_root_.relay.generated.Input | Null] = js.undefined
   ): _root_.relay.generated.TestOptionalObjectVariableMutationInput =
     _root_.relay.generated.TestOptionalObjectVariableMutationInput(
       input

--- a/sbt-scala-relay/src/sbt-test/relay-convert/mutation/expected/TestOptionalPrimitiveVariableMutation.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/mutation/expected/TestOptionalPrimitiveVariableMutation.scala
@@ -13,12 +13,12 @@ mutation TestOptionalPrimitiveVariableMutation($a: String) {
 */
 
 trait TestOptionalPrimitiveVariableMutationInput extends js.Object {
-  val a: String | Null
+  val a: js.UndefOr[String | Null]
 }
 
 object TestOptionalPrimitiveVariableMutationInput {
   def apply(
-    a: String | Null = null
+    a: js.UndefOr[String | Null] = js.undefined
   ): TestOptionalPrimitiveVariableMutationInput =
     js.Dynamic.literal(
       a = a
@@ -39,7 +39,7 @@ object TestOptionalPrimitiveVariableMutation extends _root_.com.goodcover.relay.
   }
 
   def newInput(
-    a: String | Null = null
+    a: js.UndefOr[String | Null] = js.undefined
   ): _root_.relay.generated.TestOptionalPrimitiveVariableMutationInput =
     _root_.relay.generated.TestOptionalPrimitiveVariableMutationInput(
       a

--- a/sbt-scala-relay/src/sbt-test/relay-convert/query/expected/TestNestedObjectVariableQuery.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/query/expected/TestNestedObjectVariableQuery.scala
@@ -13,12 +13,12 @@ query TestNestedObjectVariableQuery($nested: Nested) {
 */
 
 trait TestNestedObjectVariableQueryInput extends js.Object {
-  val nested: Nested | Null
+  val nested: js.UndefOr[Nested | Null]
 }
 
 object TestNestedObjectVariableQueryInput {
   def apply(
-    nested: Nested | Null = null
+    nested: js.UndefOr[Nested | Null] = js.undefined
   ): TestNestedObjectVariableQueryInput =
     js.Dynamic.literal(
       nested = nested
@@ -39,7 +39,7 @@ object TestNestedObjectVariableQuery extends _root_.com.goodcover.relay.QueryTag
   }
 
   def newInput(
-    nested: _root_.relay.generated.Nested | Null = null
+    nested: js.UndefOr[_root_.relay.generated.Nested | Null] = js.undefined
   ): _root_.relay.generated.TestNestedObjectVariableQueryInput =
     _root_.relay.generated.TestNestedObjectVariableQueryInput(
       nested

--- a/sbt-scala-relay/src/sbt-test/relay-convert/query/expected/TestOptionalListVariableQuery.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/query/expected/TestOptionalListVariableQuery.scala
@@ -13,12 +13,12 @@ query TestOptionalListVariableQuery($as: [String!]) {
 */
 
 trait TestOptionalListVariableQueryInput extends js.Object {
-  val as: js.Array[String] | Null
+  val as: js.UndefOr[js.Array[String] | Null]
 }
 
 object TestOptionalListVariableQueryInput {
   def apply(
-    as: js.Array[String] | Null = null
+    as: js.UndefOr[js.Array[String] | Null] = js.undefined
   ): TestOptionalListVariableQueryInput =
     js.Dynamic.literal(
       as = as
@@ -39,7 +39,7 @@ object TestOptionalListVariableQuery extends _root_.com.goodcover.relay.QueryTag
   }
 
   def newInput(
-    as: js.Array[String] | Null = null
+    as: js.UndefOr[js.Array[String] | Null] = js.undefined
   ): _root_.relay.generated.TestOptionalListVariableQueryInput =
     _root_.relay.generated.TestOptionalListVariableQueryInput(
       as

--- a/sbt-scala-relay/src/sbt-test/relay-convert/query/expected/TestOptionalObjectVariableQuery.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/query/expected/TestOptionalObjectVariableQuery.scala
@@ -13,12 +13,12 @@ query TestOptionalObjectVariableQuery($input: Input) {
 */
 
 trait TestOptionalObjectVariableQueryInput extends js.Object {
-  val input: Input | Null
+  val input: js.UndefOr[Input | Null]
 }
 
 object TestOptionalObjectVariableQueryInput {
   def apply(
-    input: Input | Null = null
+    input: js.UndefOr[Input | Null] = js.undefined
   ): TestOptionalObjectVariableQueryInput =
     js.Dynamic.literal(
       input = input
@@ -39,7 +39,7 @@ object TestOptionalObjectVariableQuery extends _root_.com.goodcover.relay.QueryT
   }
 
   def newInput(
-    input: _root_.relay.generated.Input | Null = null
+    input: js.UndefOr[_root_.relay.generated.Input | Null] = js.undefined
   ): _root_.relay.generated.TestOptionalObjectVariableQueryInput =
     _root_.relay.generated.TestOptionalObjectVariableQueryInput(
       input

--- a/sbt-scala-relay/src/sbt-test/relay-convert/query/expected/TestOptionalPrimitiveVariableQuery.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/query/expected/TestOptionalPrimitiveVariableQuery.scala
@@ -13,12 +13,12 @@ query TestOptionalPrimitiveVariableQuery($a: String) {
 */
 
 trait TestOptionalPrimitiveVariableQueryInput extends js.Object {
-  val a: String | Null
+  val a: js.UndefOr[String | Null]
 }
 
 object TestOptionalPrimitiveVariableQueryInput {
   def apply(
-    a: String | Null = null
+    a: js.UndefOr[String | Null] = js.undefined
   ): TestOptionalPrimitiveVariableQueryInput =
     js.Dynamic.literal(
       a = a
@@ -39,7 +39,7 @@ object TestOptionalPrimitiveVariableQuery extends _root_.com.goodcover.relay.Que
   }
 
   def newInput(
-    a: String | Null = null
+    a: js.UndefOr[String | Null] = js.undefined
   ): _root_.relay.generated.TestOptionalPrimitiveVariableQueryInput =
     _root_.relay.generated.TestOptionalPrimitiveVariableQueryInput(
       a

--- a/sbt-scala-relay/src/sbt-test/relay-convert/refetchable/expected/Args.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/refetchable/expected/Args.scala
@@ -8,12 +8,12 @@ import _root_.scala.scalajs.js.annotation.JSImport
 */
 
 trait ArgsInput extends js.Object {
-  val b: String | Null
+  val b: js.UndefOr[String | Null]
 }
 
 object ArgsInput {
   def apply(
-    b: String | Null = null
+    b: js.UndefOr[String | Null] = js.undefined
   ): ArgsInput =
     js.Dynamic.literal(
       b = b
@@ -31,7 +31,7 @@ object Args extends _root_.com.goodcover.relay.QueryTaggedNode[ArgsInput, Args] 
   }
 
   def newInput(
-    b: String | Null = null
+    b: js.UndefOr[String | Null] = js.undefined
   ): _root_.relay.generated.ArgsInput =
     _root_.relay.generated.ArgsInput(
       b

--- a/sbt-scala-relay/src/sbt-test/relay-convert/refetchable/expected/ArgsOfSpread.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/refetchable/expected/ArgsOfSpread.scala
@@ -8,12 +8,12 @@ import _root_.scala.scalajs.js.annotation.JSImport
 */
 
 trait ArgsOfSpreadInput extends js.Object {
-  val b: String | Null
+  val b: js.UndefOr[String | Null]
 }
 
 object ArgsOfSpreadInput {
   def apply(
-    b: String | Null = null
+    b: js.UndefOr[String | Null] = js.undefined
   ): ArgsOfSpreadInput =
     js.Dynamic.literal(
       b = b
@@ -31,7 +31,7 @@ object ArgsOfSpread extends _root_.com.goodcover.relay.QueryTaggedNode[ArgsOfSpr
   }
 
   def newInput(
-    b: String | Null = null
+    b: js.UndefOr[String | Null] = js.undefined
   ): _root_.relay.generated.ArgsOfSpreadInput =
     _root_.relay.generated.ArgsOfSpreadInput(
       b

--- a/sbt-scala-relay/src/sbt-test/relay-convert/refetchable/expected/NestedArgs.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/refetchable/expected/NestedArgs.scala
@@ -8,12 +8,12 @@ import _root_.scala.scalajs.js.annotation.JSImport
 */
 
 trait NestedArgsInput extends js.Object {
-  val b: String | Null
+  val b: js.UndefOr[String | Null]
 }
 
 object NestedArgsInput {
   def apply(
-    b: String | Null = null
+    b: js.UndefOr[String | Null] = js.undefined
   ): NestedArgsInput =
     js.Dynamic.literal(
       b = b
@@ -31,7 +31,7 @@ object NestedArgs extends _root_.com.goodcover.relay.QueryTaggedNode[NestedArgsI
   }
 
   def newInput(
-    b: String | Null = null
+    b: js.UndefOr[String | Null] = js.undefined
   ): _root_.relay.generated.NestedArgsInput =
     _root_.relay.generated.NestedArgsInput(
       b

--- a/sbt-scala-relay/src/sbt-test/relay-convert/refetchable/expected/ObjectArgs.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/refetchable/expected/ObjectArgs.scala
@@ -8,12 +8,12 @@ import _root_.scala.scalajs.js.annotation.JSImport
 */
 
 trait ObjectArgsInput extends js.Object {
-  val thing: Thing | Null
+  val thing: js.UndefOr[Thing | Null]
 }
 
 object ObjectArgsInput {
   def apply(
-    thing: Thing | Null = null
+    thing: js.UndefOr[Thing | Null] = js.undefined
   ): ObjectArgsInput =
     js.Dynamic.literal(
       thing = thing
@@ -31,7 +31,7 @@ object ObjectArgs extends _root_.com.goodcover.relay.QueryTaggedNode[ObjectArgsI
   }
 
   def newInput(
-    thing: _root_.relay.generated.Thing | Null = null
+    thing: js.UndefOr[_root_.relay.generated.Thing | Null] = js.undefined
   ): _root_.relay.generated.ObjectArgsInput =
     _root_.relay.generated.ObjectArgsInput(
       thing

--- a/sbt-scala-relay/src/sbt-test/relay-convert/refetchable/expected/Stuff.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/refetchable/expected/Stuff.scala
@@ -10,12 +10,12 @@ input Stuff {
 */
 
 trait Stuff extends js.Object {
-  val junk: String | Null
+  val junk: js.UndefOr[String | Null]
 }
 
 object Stuff {
   def apply(
-    junk: String | Null = null
+    junk: js.UndefOr[String | Null] = js.undefined
   ): Stuff =
     js.Dynamic.literal(
       junk = junk

--- a/sbt-scala-relay/src/sbt-test/relay-convert/scalajs-directive-client-type/expected/ClientTypeInput.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/scalajs-directive-client-type/expected/ClientTypeInput.scala
@@ -17,22 +17,22 @@ input ClientTypeInput {
 
 trait ClientTypeInput extends js.Object {
   val required: String[Required]
-  val optional: String[Optional] | Null
+  val optional: js.UndefOr[String[Optional] | Null]
   val requiredListRequiredElements: js.Array[String[RequiredListRequiredElements]]
-  val requiredListOptionalElements: js.Array[String[RequiredListOptionalElements] | Null]
-  val optionalListRequiredElements: js.Array[String[OptionalListRequiredElements]] | Null
-  val optionalListOptionalElements: js.Array[String[OptionalListOptionalElements] | Null] | Null
+  val requiredListOptionalElements: js.Array[js.UndefOr[String[RequiredListOptionalElements] | Null]]
+  val optionalListRequiredElements: js.UndefOr[js.Array[String[OptionalListRequiredElements]] | Null]
+  val optionalListOptionalElements: js.UndefOr[js.Array[js.UndefOr[String[OptionalListOptionalElements] | Null]] | Null]
   val nested: ClientTypeNestedInput
 }
 
 object ClientTypeInput {
   def apply(
     required: String[Required],
-    optional: String[Optional] | Null = null,
+    optional: js.UndefOr[String[Optional] | Null] = js.undefined,
     requiredListRequiredElements: js.Array[String[RequiredListRequiredElements]],
-    requiredListOptionalElements: js.Array[String[RequiredListOptionalElements] | Null],
-    optionalListRequiredElements: js.Array[String[OptionalListRequiredElements]] | Null = null,
-    optionalListOptionalElements: js.Array[String[OptionalListOptionalElements] | Null] | Null = null,
+    requiredListOptionalElements: js.Array[js.UndefOr[String[RequiredListOptionalElements] | Null]],
+    optionalListRequiredElements: js.UndefOr[js.Array[String[OptionalListRequiredElements]] | Null] = js.undefined,
+    optionalListOptionalElements: js.UndefOr[js.Array[js.UndefOr[String[OptionalListOptionalElements] | Null]] | Null] = js.undefined,
     nested: ClientTypeNestedInput
   ): ClientTypeInput =
     js.Dynamic.literal(

--- a/sbt-scala-relay/src/sbt-test/relay-convert/subscription/expected/TestNestedObjectVariableSubscription.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/subscription/expected/TestNestedObjectVariableSubscription.scala
@@ -13,12 +13,12 @@ subscription TestNestedObjectVariableSubscription($nested: Nested) {
 */
 
 trait TestNestedObjectVariableSubscriptionInput extends js.Object {
-  val nested: Nested | Null
+  val nested: js.UndefOr[Nested | Null]
 }
 
 object TestNestedObjectVariableSubscriptionInput {
   def apply(
-    nested: Nested | Null = null
+    nested: js.UndefOr[Nested | Null] = js.undefined
   ): TestNestedObjectVariableSubscriptionInput =
     js.Dynamic.literal(
       nested = nested
@@ -39,7 +39,7 @@ object TestNestedObjectVariableSubscription extends _root_.com.goodcover.relay.S
   }
 
   def newInput(
-    nested: _root_.relay.generated.Nested | Null = null
+    nested: js.UndefOr[_root_.relay.generated.Nested | Null] = js.undefined
   ): _root_.relay.generated.TestNestedObjectVariableSubscriptionInput =
     _root_.relay.generated.TestNestedObjectVariableSubscriptionInput(
       nested

--- a/sbt-scala-relay/src/sbt-test/relay-convert/subscription/expected/TestOptionalListVariableSubscription.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/subscription/expected/TestOptionalListVariableSubscription.scala
@@ -13,12 +13,12 @@ subscription TestOptionalListVariableSubscription($as: [String!]) {
 */
 
 trait TestOptionalListVariableSubscriptionInput extends js.Object {
-  val as: js.Array[String] | Null
+  val as: js.UndefOr[js.Array[String] | Null]
 }
 
 object TestOptionalListVariableSubscriptionInput {
   def apply(
-    as: js.Array[String] | Null = null
+    as: js.UndefOr[js.Array[String] | Null] = js.undefined
   ): TestOptionalListVariableSubscriptionInput =
     js.Dynamic.literal(
       as = as
@@ -39,7 +39,7 @@ object TestOptionalListVariableSubscription extends _root_.com.goodcover.relay.S
   }
 
   def newInput(
-    as: js.Array[String] | Null = null
+    as: js.UndefOr[js.Array[String] | Null] = js.undefined
   ): _root_.relay.generated.TestOptionalListVariableSubscriptionInput =
     _root_.relay.generated.TestOptionalListVariableSubscriptionInput(
       as

--- a/sbt-scala-relay/src/sbt-test/relay-convert/subscription/expected/TestOptionalObjectVariableSubscription.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/subscription/expected/TestOptionalObjectVariableSubscription.scala
@@ -13,12 +13,12 @@ subscription TestOptionalObjectVariableSubscription($input: Input) {
 */
 
 trait TestOptionalObjectVariableSubscriptionInput extends js.Object {
-  val input: Input | Null
+  val input: js.UndefOr[Input | Null]
 }
 
 object TestOptionalObjectVariableSubscriptionInput {
   def apply(
-    input: Input | Null = null
+    input: js.UndefOr[Input | Null] = js.undefined
   ): TestOptionalObjectVariableSubscriptionInput =
     js.Dynamic.literal(
       input = input
@@ -39,7 +39,7 @@ object TestOptionalObjectVariableSubscription extends _root_.com.goodcover.relay
   }
 
   def newInput(
-    input: _root_.relay.generated.Input | Null = null
+    input: js.UndefOr[_root_.relay.generated.Input | Null] = js.undefined
   ): _root_.relay.generated.TestOptionalObjectVariableSubscriptionInput =
     _root_.relay.generated.TestOptionalObjectVariableSubscriptionInput(
       input

--- a/sbt-scala-relay/src/sbt-test/relay-convert/subscription/expected/TestOptionalPrimitiveVariableSubscription.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/subscription/expected/TestOptionalPrimitiveVariableSubscription.scala
@@ -13,12 +13,12 @@ subscription TestOptionalPrimitiveVariableSubscription($a: String) {
 */
 
 trait TestOptionalPrimitiveVariableSubscriptionInput extends js.Object {
-  val a: String | Null
+  val a: js.UndefOr[String | Null]
 }
 
 object TestOptionalPrimitiveVariableSubscriptionInput {
   def apply(
-    a: String | Null = null
+    a: js.UndefOr[String | Null] = js.undefined
   ): TestOptionalPrimitiveVariableSubscriptionInput =
     js.Dynamic.literal(
       a = a
@@ -39,7 +39,7 @@ object TestOptionalPrimitiveVariableSubscription extends _root_.com.goodcover.re
   }
 
   def newInput(
-    a: String | Null = null
+    a: js.UndefOr[String | Null] = js.undefined
   ): _root_.relay.generated.TestOptionalPrimitiveVariableSubscriptionInput =
     _root_.relay.generated.TestOptionalPrimitiveVariableSubscriptionInput(
       a

--- a/sbt-scala-relay/src/sbt-test/relay-convert/type-mapping/expected/ClientTypeInput.scala
+++ b/sbt-scala-relay/src/sbt-test/relay-convert/type-mapping/expected/ClientTypeInput.scala
@@ -18,27 +18,27 @@ input ClientTypeInput {
 */
 
 trait ClientTypeInput extends js.Object {
-  val id: String | Null
-  val number: Double | Null
+  val id: js.UndefOr[String | Null]
+  val number: js.UndefOr[Double | Null]
   val required: Bar
-  val optional: Bar | Null
+  val optional: js.UndefOr[Bar | Null]
   val requiredListRequiredElements: js.Array[Bar]
-  val requiredListOptionalElements: js.Array[Bar | Null]
-  val optionalListRequiredElements: js.Array[Bar] | Null
-  val optionalListOptionalElements: js.Array[Bar | Null] | Null
+  val requiredListOptionalElements: js.Array[js.UndefOr[Bar | Null]]
+  val optionalListRequiredElements: js.UndefOr[js.Array[Bar] | Null]
+  val optionalListOptionalElements: js.UndefOr[js.Array[js.UndefOr[Bar | Null]] | Null]
   val nested: ClientTypeNestedInput
 }
 
 object ClientTypeInput {
   def apply(
-    id: String | Null = null,
-    number: Double | Null = null,
+    id: js.UndefOr[String | Null] = js.undefined,
+    number: js.UndefOr[Double | Null] = js.undefined,
     required: Bar,
-    optional: Bar | Null = null,
+    optional: js.UndefOr[Bar | Null] = js.undefined,
     requiredListRequiredElements: js.Array[Bar],
-    requiredListOptionalElements: js.Array[Bar | Null],
-    optionalListRequiredElements: js.Array[Bar] | Null = null,
-    optionalListOptionalElements: js.Array[Bar | Null] | Null = null,
+    requiredListOptionalElements: js.Array[js.UndefOr[Bar | Null]],
+    optionalListRequiredElements: js.UndefOr[js.Array[Bar] | Null] = js.undefined,
+    optionalListOptionalElements: js.UndefOr[js.Array[js.UndefOr[Bar | Null]] | Null] = js.undefined,
     nested: ClientTypeNestedInput
   ): ClientTypeInput =
     js.Dynamic.literal(

--- a/scala-relay-core/src/main/scala-2/com/goodcover/relay/UnionImplicits.scala
+++ b/scala-relay-core/src/main/scala-2/com/goodcover/relay/UnionImplicits.scala
@@ -1,5 +1,6 @@
 package com.goodcover.relay
 
+import scala.annotation.unused
 import scala.scalajs.js
 import scala.scalajs.js.|
 import scala.scalajs.js.|.Evidence
@@ -42,8 +43,11 @@ trait UnionImplicits {
   implicit val stringEv: Evidence[String, js.Any] =
     baseEv.asInstanceOf[Evidence[String, js.Any]]
 
-  implicit def mergeUnion[A, B, C](ab: A | B)(implicit evA: Evidence[A, C], evB: Evidence[B, C]): C =
+  implicit def mergeUnion[A, B, C](ab: A | B)(implicit @unused evA: Evidence[A, C], @unused evB: Evidence[B, C]): C =
     ab.asInstanceOf[C]
+
+  implicit def undefOrToJsAny[A](ab: js.UndefOr[A])(implicit @unused evA: Evidence[A, js.Any]): js.Any =
+    ab.asInstanceOf[js.Any]
 
 }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.45.1-SNAPSHOT"
+ThisBuild / version := "0.46.0-SNAPSHOT"


### PR DESCRIPTION
I tried a bunch of way to make this nice but it's pretty terrible in Scala 2. In Scala 3 it just works.

If you use `toOrNull` (which we do) then it fails with:
```
polymorphic expression cannot be instantiated to expected type;
 found   : [B]B | Null
 required: scala.scalajs.js.UndefOr[Int | Null]
    (which expands to)  Int | Null | Unit [117:28]
```

You have to explicitly type it with `toOrNull[Int]` before it will do the implicit conversion to `UndefOr` which sucks.

I'm thinking of abandoning this, at least until Scala 3. Thoughts?